### PR TITLE
Support code auth on iOS via client secret

### DIFF
--- a/ios/RNSpotifyAuth.h
+++ b/ios/RNSpotifyAuth.h
@@ -18,6 +18,7 @@
 
 @property (nonatomic, readonly) NSString* clientID;
 @property (nonatomic, readonly) NSURL* tokenRefreshURL;
+@property (nonatomic, readonly) NSString* clientSecret;
 
 @property (nonatomic, readonly) RNSpotifySessionData* session;
 
@@ -35,7 +36,8 @@
 -(void)renewSessionIfNeeded:(RNSpotifyCompletion*)completion waitForDefinitiveResponse:(BOOL)waitForDefinitiveResponse;
 -(void)renewSession:(RNSpotifyCompletion*)completion waitForDefinitiveResponse:(BOOL)waitForDefinitiveResponse;
 
++(NSString *)getAuthorizationHeader:(NSString *)clientSecret clientID:(NSString *)clientID;
 +(void)performTokenURLRequestTo:(NSURL*)url params:(NSDictionary*)params completion:(RNSpotifyCompletion<NSDictionary*>*)completion;
-+(void)swapCodeForToken:(NSString*)code url:(NSURL*)url completion:(RNSpotifyCompletion<RNSpotifySessionData*>*)completion;
++(void)swapCodeForToken:(NSString*)code url:(NSURL*)url clientSecret:(NSString *)clientSecret clientID:(NSString *)clientID redirectURL:(NSURL*)redirectURL completion:(RNSpotifyCompletion<RNSpotifySessionData*>*)completion;
 
 @end

--- a/ios/RNSpotifyAuthController.m
+++ b/ios/RNSpotifyAuthController.m
@@ -177,11 +177,11 @@
 	}
 	else if(params[@"code"] != nil) {
 		// authentication code
-		if(_options.tokenSwapURL == nil) {
+		if(_options.tokenSwapURL == nil && _options.clientSecret == nil) {
 			[_completion reject:[RNSpotifyError missingOptionErrorForName:@"tokenSwapURL"]];
 			return;
 		}
-		[RNSpotifyAuth swapCodeForToken:params[@"code"] url:_options.tokenSwapURL completion:[RNSpotifyCompletion onReject:^(RNSpotifyError *error) {
+		[RNSpotifyAuth swapCodeForToken:params[@"code"] url:_options.tokenSwapURL clientSecret:_options.clientSecret clientID: _options.clientID redirectURL: _options.redirectURL completion:[RNSpotifyCompletion onReject:^(RNSpotifyError *error) {
 			dispatch_async(dispatch_get_main_queue(), ^{
 				[_completion reject:error];
 			});

--- a/ios/RNSpotifyLoginOptions.h
+++ b/ios/RNSpotifyLoginOptions.h
@@ -11,6 +11,7 @@
 
 @interface RNSpotifyLoginOptions : NSObject
 @property (nonatomic) NSString* clientID;
+@property (nonatomic) NSString* clientSecret;
 @property (nonatomic) NSURL* redirectURL;
 @property (nonatomic) NSArray<NSString*>* scopes;
 @property (nonatomic) NSURL* tokenSwapURL;

--- a/ios/RNSpotifyLoginOptions.m
+++ b/ios/RNSpotifyLoginOptions.m
@@ -18,7 +18,7 @@
 	if(_clientID != nil) {
 		[queryItems addObject:[NSURLQueryItem queryItemWithName:@"client_id" value:_clientID]];
 	}
-	if(_tokenSwapURL != nil) {
+	if(_tokenSwapURL != nil || _clientSecret != nil) {
 		[queryItems addObject:[NSURLQueryItem queryItemWithName:@"response_type" value:@"code"]];
 	}
 	else {
@@ -57,6 +57,24 @@
 
 +(RNSpotifyLoginOptions*)optionsFromDictionary:(NSDictionary*)dict fallback:(NSDictionary*)fallbackDict ignore:(NSArray<NSString*>*)ignore error:(RNSpotifyError**)error {
 	RNSpotifyLoginOptions* options = [[RNSpotifyLoginOptions alloc] init];
+
+	//clientSecret
+	options.clientSecret = [RNSpotifyUtils getOption:@"clientSecret" from:dict fallback:fallbackDict];
+	if(options.clientSecret == nil) {
+		if(![ignore containsObject:@"clientSecret"]) {
+			if(error != nil) {
+				*error = [RNSpotifyError missingOptionErrorForName:@"clientSecret"];
+			}
+			return nil;
+		}
+	}
+	else if(![options.clientSecret isKindOfClass:[NSString class]]) {
+		if(error != nil) {
+			*error = [RNSpotifyError errorWithCodeObj:RNSpotifyErrorCode.BadParameter message:@"clientSecret must be a string"];
+		}
+		return nil;
+	}
+
 	// clientID
 	options.clientID = [RNSpotifyUtils getOption:@"clientID" from:dict fallback:fallbackDict];
 	if(options.clientID == nil) {


### PR DESCRIPTION
This commit adds the support for code authentication without
the necessity of using a remote server. #This is very insecure since
Using this approach is not secure, however for testing it should
be enough.