### PR TITLE
Add support for clientSecret to Android

### DIFF
--- a/android/src/main/java/com/lufinkey/react/spotify/AuthActivity.java
+++ b/android/src/main/java/com/lufinkey/react/spotify/AuthActivity.java
@@ -100,12 +100,12 @@ public class AuthActivity extends Activity
 						listener.onAuthActivityFailure(this, new SpotifyError("state_mismatch", "state mismatch"));
 						return;
 					}*/
-					if(options.tokenSwapURL == null) {
+					if(options.tokenSwapURL == null && options.clientSecret == null) {
 						listener.onAuthActivityFailure(this, SpotifyError.getMissingOptionError("tokenSwapURL"));
 						return;
 					}
 					final AuthActivity authActivity = this;
-					Auth.swapCodeForToken(response.getCode(), options.tokenSwapURL, new Completion<SessionData>() {
+					Auth.swapCodeForToken(response.getCode(), options.tokenSwapURL, options.clientSecret, options.clientID, options.redirectURL, new Completion<SessionData>() {
 						@Override
 						public void onReject(SpotifyError error) {
 							listener.onAuthActivityFailure(authActivity, error);

--- a/android/src/main/java/com/lufinkey/react/spotify/LoginOptions.java
+++ b/android/src/main/java/com/lufinkey/react/spotify/LoginOptions.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 
 public class LoginOptions {
 	public String clientID = null;
+	public String clientSecret = null;
 	public String redirectURL = null;
 	public String[] scopes = null;
 	public String tokenSwapURL = null;
@@ -20,7 +21,7 @@ public class LoginOptions {
 
 	AuthenticationRequest getAuthenticationRequest(String state) {
 		AuthenticationResponse.Type responseType = AuthenticationResponse.Type.TOKEN;
-		if(tokenSwapURL != null) {
+		if(tokenSwapURL != null || clientSecret != null) {
 			responseType = AuthenticationResponse.Type.CODE;
 		}
 		AuthenticationRequest.Builder requestBuilder = new AuthenticationRequest.Builder(clientID, responseType, redirectURL);
@@ -68,6 +69,9 @@ public class LoginOptions {
 		// tokenSwapURL
 		Dynamic tokenSwapURL = Utils.getOption("tokenSwapURL", dict, fallback);
 		options.tokenSwapURL = (tokenSwapURL != null) ? tokenSwapURL.asString() : null;
+		// clientSecret
+		Dynamic clientSecret = Utils.getOption("clientSecret", dict, fallback);
+		options.clientSecret = (clientSecret != null) ? clientSecret.asString() : null;
 		// tokenRefreshURL
 		Dynamic tokenRefreshURL = Utils.getOption("tokenRefreshURL", dict, fallback);
 		options.tokenRefreshURL = (tokenRefreshURL != null) ? tokenRefreshURL.asString() : null;

--- a/android/src/main/java/com/lufinkey/react/spotify/RNSpotifyModule.java
+++ b/android/src/main/java/com/lufinkey/react/spotify/RNSpotifyModule.java
@@ -288,7 +288,7 @@ public class RNSpotifyModule extends ReactContextBaseJavaModule implements Playe
 
 
 	private void renewSessionIfNeeded(final Completion<Boolean> completion, boolean waitForDefinitiveResponse) {
-		if(auth.isLoggedIn() || auth.isSessionValid()) {
+		if(!auth.isLoggedIn() || auth.isSessionValid()) {
 			// not logged in or session does not need renewal
 			completion.resolve(false);
 		}


### PR DESCRIPTION
Add support for clientSecret to Android to allow code grant_type without
the need of a server.