### PR TITLE
Disable auto-refresh

### DIFF
--- a/android/src/main/java/com/lufinkey/react/spotify/RNSpotifyModule.java
+++ b/android/src/main/java/com/lufinkey/react/spotify/RNSpotifyModule.java
@@ -209,9 +209,7 @@ public class RNSpotifyModule extends ReactContextBaseJavaModule implements Playe
 		logBackInIfNeeded(new Completion<Boolean>() {
 			@Override
 			public void onComplete(Boolean loggedIn, SpotifyError error) {
-				if(loggedIn != null && loggedIn) {
-					startAuthRenewalTimer();
-				}
+				// Done
 			}
 		}, true);
 	}
@@ -340,11 +338,6 @@ public class RNSpotifyModule extends ReactContextBaseJavaModule implements Playe
 		renewSession(new Completion<Boolean>() {
 			@Override
 			public void onResolve(Boolean renewed) {
-				// ensure the timer has not been stopped
-				if(authRenewalTimer != null && renewed) {
-					// reschedule the timer
-					scheduleAuthRenewalTimer();
-				}
 				promise.resolve(renewed);
 			}
 
@@ -702,7 +695,6 @@ public class RNSpotifyModule extends ReactContextBaseJavaModule implements Playe
 									if (loggedIn) {
 										sendEvent("login", Convert.fromSessionData(auth.getSession()));
 									}
-									startAuthRenewalTimer();
 								}
 							}
 						});

--- a/ios/RNSpotify.m
+++ b/ios/RNSpotify.m
@@ -233,11 +233,9 @@ RCT_EXPORT_METHOD(initialize:(NSDictionary*)options resolve:(RCTPromiseResolveBl
 	if(_loggedIn) {
 		[self sendEvent:@"login" args:@[[RNSpotifyConvert RNSpotifySessionData:_auth.session]]];
 	}
-	
+
 	[self logBackInIfNeeded:[RNSpotifyCompletion<NSNumber*> onComplete:^(NSNumber* loggedIn, RNSpotifyError* error) {
-		if(loggedIn != nil && loggedIn.boolValue && [[self isLoggedIn] boolValue]) {
-			[self startAuthRenewalTimer];
-		}
+		// done
 	}] waitForDefinitiveResponse:YES];
 }
 
@@ -359,11 +357,6 @@ RCT_EXPORT_METHOD(isInitializedAsync:(RCTPromiseResolveBlock)resolve reject:(RCT
 
 RCT_EXPORT_METHOD(renewSession:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
 	[self renewSession:[RNSpotifyCompletion onResolve:^(NSNumber* renewed) {
-		// ensure we're logged in
-		if(_loggedIn && renewed.boolValue) {
-			// reschedule the timer
-			[self scheduleAuthRenewalTimer];
-		}
 		resolve(renewed);
 	} onReject:^(RNSpotifyError* error) {
 		[error reject:reject];
@@ -599,7 +592,6 @@ RCT_EXPORT_METHOD(login:(NSDictionary*)options resolve:(RCTPromiseResolveBlock)r
 								if(_loggedIn) {
 									[self sendEvent:@"login" args:@[[RNSpotifyConvert RNSpotifySessionData:_auth.session]]];
 								}
-								[self startAuthRenewalTimer];
 							}
 						}];
 					});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "bugs": {
     "url": "https://github.com/lufinkey/react-native-spotify/issues"
   },
-  "version": "1.2.19",
+  "version": "1.2.20",
   "description": "A react-native module for the Spotify SDK",
   "author": "lufinkey",
   "nativePackage": true,


### PR DESCRIPTION
Auto-renewal seems to be the cause for the flooding that we've been
experiencing in our spotify refresh endpoints. On this commit, we're
disabling it since it's not really needed for our use case. The requests
that we send to the spotify sdk will always confirm if the tokens are
still valid before sending requests (refreshing if not).